### PR TITLE
develop

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,22 +1,23 @@
 // biome-ignore lint/style/useNamingConvention: <explanation>
-import createMDX from '@next/mdx';
-import rehypeAutoLinkHeadings from 'rehype-autolink-headings';
-import rehypeKatex from 'rehype-katex';
-import rehypePrettyCode from 'rehype-pretty-code';
-import rehypeSlug from 'rehype-slug';
-import rehypeStringify from 'rehype-stringify';
-import remarkGemoji from 'remark-gemoji';
-import remarkGfm from 'remark-gfm';
-import remarkMath from 'remark-math';
-import remarkToc from 'remark-toc';
-import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
+import createMDX from "@next/mdx";
+import rehypeAutoLinkHeadings from "rehype-autolink-headings";
+import rehypeKatex from "rehype-katex";
+import rehypePrettyCode from "rehype-pretty-code";
+import rehypeSlug from "rehype-slug";
+import rehypeStringify from "rehype-stringify";
+import remarkGemoji from "remark-gemoji";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import remarkToc from "remark-toc";
+import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "standalone",
   trailingSlash: true,
   reactStrictMode: true,
   swcMinify: true,
-  pageExtensions: ['tsx', 'mdx'],
+  pageExtensions: ["tsx", "mdx"],
   images: {
     unoptimized: true,
   },
@@ -27,7 +28,7 @@ const nextConfig = {
     // ------------------ SVG ------------------
     // Grab the existing rule that handles SVG imports
     const fileLoaderRule = config.module.rules.find((rule) =>
-      rule.test?.test?.('.svg'),
+      rule.test?.test?.(".svg"),
     );
     config.module.rules.push(
       {
@@ -40,7 +41,7 @@ const nextConfig = {
         test: /\.svg$/i,
         issuer: fileLoaderRule.issuer,
         resourceQuery: { not: [...fileLoaderRule.resourceQuery.not, /url/] }, // exclude if *.svg?url
-        use: ['@svgr/webpack'],
+        use: ["@svgr/webpack"],
       },
     );
     // Modify the file loader rule to ignore *.svg, since we have it handled now.
@@ -49,7 +50,7 @@ const nextConfig = {
     // ------------------ MDX ------------------
     config.resolve.plugins = [
       new TsconfigPathsPlugin({
-        extensions: ['.ts', '.tsx', '.mdx'],
+        extensions: [".ts", ".tsx", ".mdx"],
       }),
     ];
 
@@ -64,31 +65,31 @@ const withMDX = createMDX({
       remarkGfm,
       remarkGemoji,
       remarkMath,
-      [remarkToc, { heading: '目次', tight: true }],
+      [remarkToc, { heading: "目次", tight: true }],
     ],
     rehypePlugins: [
       rehypeSlug,
       [
         rehypeAutoLinkHeadings,
         {
-          behavior: 'append',
-          properties: { 'aria-label': 'heading-link' },
+          behavior: "append",
+          properties: { "aria-label": "heading-link" },
         },
       ],
       [
         rehypePrettyCode,
         {
-          theme: 'github-dark',
+          theme: "github-dark",
           onVisitLine(node) {
             if (node.children.length === 0) {
-              node.children = [{ type: 'text', value: ' ' }];
+              node.children = [{ type: "text", value: " " }];
             }
           },
           onVisitHighlightedLine(node) {
-            node.properties.className?.push('line--highlighted');
+            node.properties.className?.push("line--highlighted");
           },
           onVisitHighlightedChars(node) {
-            node.properties.className = ['word--highlighted'];
+            node.properties.className = ["word--highlighted"];
           },
         },
       ],
@@ -97,10 +98,10 @@ const withMDX = createMDX({
     ],
     remarkRehypeOptions: {
       allowDangerousHtml: true,
-      footnoteLabel: '脚注',
-      footnoteBackLabel: '戻る',
+      footnoteLabel: "脚注",
+      footnoteBackLabel: "戻る",
     },
-    format: 'mdx',
+    format: "mdx",
   },
 });
 


### PR DESCRIPTION
- **Bump @types/node from 20.11.25 to 20.12.2**
- **Bump katex from 0.16.9 to 0.16.10**
- **Bump next from 14.1.0 to 14.1.4**
- **remove framer-motion**
- **Bump typescript from 5.3.3 to 5.4.5**
- **quit bun**
- **update**
- **fix scripts**
- **Update imports and configurations in next.config.mjs**
- **fix**
- **update**
