### PR TITLE
develop

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,8 @@ import remarkMath from "remark-math";
 import remarkToc from "remark-toc";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
+export const runtime = "edge";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",


### PR DESCRIPTION
- **Bump @types/node from 20.11.25 to 20.12.2**
- **Bump katex from 0.16.9 to 0.16.10**
- **Bump next from 14.1.0 to 14.1.4**
- **remove framer-motion**
- **Bump typescript from 5.3.3 to 5.4.5**
- **quit bun**
- **update**
- **fix scripts**
- **Update imports and configurations in next.config.mjs**
- **fix**
- **update**
- **Add @cloudflare/next-on-pages as a dev dependency**
- **Add runtime option for edge environment**
