### PR TITLE
develop

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,7 +13,7 @@ import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "standalone",
+  output: "export",
   trailingSlash: true,
   reactStrictMode: true,
   swcMinify: true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "vercel-build": "next build",
     "build:next": "next build",
     "build-storybook": "storybook build",
-    "build:prod": "run-s setup build:next-on-pages sitemap",
+    "build:prod": "run-s setup build:next sitemap",
     "build:next-on-pages": "pnpx @cloudflare/next-on-pages",
     "dev": "run-p dev:*",
     "dev:next": "next dev",
@@ -115,3 +115,4 @@
     "webpack": "^5.91.0"
   }
 }
+

--- a/src/app/blog/[...slug]/page.tsx
+++ b/src/app/blog/[...slug]/page.tsx
@@ -21,7 +21,6 @@ import {
   metadataBase,
 } from '~/lib/sharedmetadata';
 
-export const runtime = "edge"
 type Params = { slug: string[] }; // [...slug]
 
 export async function generateMetadata({

--- a/src/app/news/[...slug]/page.tsx
+++ b/src/app/news/[...slug]/page.tsx
@@ -21,7 +21,6 @@ import {
 
 type Params = { slug: string[] }; // [...slug]
 
-export const runtime = 'edge';
 export async function generateMetadata({
   params,
 }: {


### PR DESCRIPTION
- **Bump @types/node from 20.11.25 to 20.12.2**
- **Bump katex from 0.16.9 to 0.16.10**
- **Bump next from 14.1.0 to 14.1.4**
- **remove framer-motion**
- **Bump typescript from 5.3.3 to 5.4.5**
- **quit bun**
- **update**
- **fix scripts**
- **Update imports and configurations in next.config.mjs**
- **fix**
- **update**
- **Add @cloudflare/next-on-pages as a dev dependency**
- **Add runtime option for edge environment**
- **Remove redundant runtime export and add Vercel build script**
- **fix**
