### PR TITLE
chore: bump and pin CI actions to latest majors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,10 +23,10 @@ jobs:
       version_tag: ${{ steps.get-version.outputs.version }}
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup | Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: ".bun-version"
 
@@ -55,7 +55,7 @@ jobs:
           echo "version=${version}" >> $GITHUB_OUTPUT
 
       - name: Cache content repo
-        uses: actions/cache@v4
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             content/.git
@@ -70,7 +70,7 @@ jobs:
           GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
 
       - name: Run | Deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         id: deploy-preview
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -107,10 +107,10 @@ jobs:
       url: ${{ steps.publish.outputs.deployment-url }}
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup | Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: ".bun-version"
 
@@ -137,7 +137,7 @@ jobs:
           echo "version_id=${version_id}" >> "$GITHUB_OUTPUT"
 
       - name: Run | Publish
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         id: publish
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v7.0.0
- `actions/cache` v4 → v6.0.0
- `oven-sh/setup-bun` v2 → v2.2.0
- `cloudflare/wrangler-action` v3 → v4.0.0

## Notes
- All actions are pinned to full commit SHA with a trailing version comment for supply-chain security
- `wrangler-action@v4` defaults to Wrangler v4; if CI breaks on the deploy commands, pin `wranglerVersion: "3.90.0"` in `with`
- `actions/checkout@v5+` and `actions/cache@v5+` require Actions Runner ≥ v2.327.1 (GitHub-hosted runners are fine)