### PR TITLE
[codex] Require join page secrets for deploy

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,6 +6,9 @@
     "directory": "./dist",
     "not_found_handling": "404-page"
   },
+  "secrets": {
+    "required": ["DISCORD_INVITE", "TUAT_CIDR"]
+  },
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true


### PR DESCRIPTION
## Summary

- Declare `DISCORD_INVITE` and `TUAT_CIDR` as required Wrangler secrets.
- Make `wrangler versions upload` fail early if those production bindings are missing instead of deploying a Worker version that cannot serve the gated `/join` invite correctly.
- Stop Wrangler from inferring unrelated local `.env` keys as Worker bindings during type generation.

## Root Cause

The `/join` implementation works in the Cloudflare adapter path, but the Worker config did not declare the runtime secrets it depends on. With the current versions-based deploy flow, a deploy can succeed without validating that `DISCORD_INVITE` and `TUAT_CIDR` are configured on the Worker version.

## Validation

- `bun test src/libs/inCidr.test.ts` passed: 12 tests, 0 failures.
- `nr build` passed. After the change, generated Worker types include only `DISCORD_INVITE` and `TUAT_CIDR` as string env bindings, not unrelated `.env` keys.
- `nr preview` with `CF-Connecting-IP` checks:
  - CIDR-matching IP: `discord.gg=true`, `/join/manual=true`
  - non-matching IP: `discord.gg=false`, `/join/manual=true`

## Known Existing Failures

- `nr typecheck` still fails on existing `src/libs/inCidr.test.ts` because `bun:test` types are not configured for `astro check`.
- `nr lint` still fails on existing Biome import-order findings unrelated to this config change.